### PR TITLE
Fix issue #8 to reconnect when broker gracefully closes.

### DIFF
--- a/src/AmqpConnectionManager.coffee
+++ b/src/AmqpConnectionManager.coffee
@@ -111,6 +111,13 @@ class AmqpConnectionManager extends EventEmitter
                         console.error ("amqp-connection-manager: AmqpConnectionManager:_connect()" +
                             " - How did you get here?"), err.stack
 
+                # Reconnect if the connection closes gracefully
+                connection.on 'close', =>
+                    @_currentConnection = null
+
+                    wait @reconnectTimeInSeconds * 1000
+                    .then => @_connect()
+
                 @emit 'connect', {connection, url}
 
                 return null


### PR DESCRIPTION
This should fix issue #8.  I tested by running "service rabbitmq-server restart" on the broker and witnessing connections reconnect after this patch was applied.