### PR TITLE
upgrade lodash to 4.15, promise-breaker to 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "lib/index.js",
   "dependencies": {
     "es6-promise": "^3.0.2",
-    "lodash": "^3.10.1",
-    "promise-breaker": "^2.0.3",
+    "lodash": "^4.15.0",
+    "promise-breaker": "^3.0.0",
     "when": "^3.7.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
Lodash and promise breaker have fallen behind; this pr bumps them to latest.

[Breaking changes](https://github.com/jwalton/node-promise-breaker/blob/master/CHANGELOG.md) in promise-breaker centered around `pb.make`, a method which is not used in this codebase.

[Breaking changes](https://github.com/lodash/lodash/wiki/Changelog#v400) in lodash do not include any of the methods used in this repo: `_.without`, `_.isArray`, and `_.startsWith`