### PR TITLE
Fixed queued message never got sent after server gracefully closed connection

### DIFF
--- a/src/AmqpConnectionManager.coffee
+++ b/src/AmqpConnectionManager.coffee
@@ -118,8 +118,9 @@ class AmqpConnectionManager extends EventEmitter
                             " - How did you get here?"), err.stack
 
                 # Reconnect if the connection closes gracefully
-                connection.on 'close', =>
+                connection.on 'close', (err) =>
                     @_currentConnection = null
+                    @emit 'disconnect', {err}
 
                     wait @reconnectTimeInSeconds * 1000
                     .then => @_connect()

--- a/test/fixtures.coffee
+++ b/test/fixtures.coffee
@@ -10,6 +10,9 @@ class exports.FakeAmqp
     kill: ->
         @connection.emit 'error', new Error("Died in a fire")
 
+    close: ->
+        @connection.emit 'close', new Error("Connection closed")
+
     reset: ->
         @connection = null
         @url = null


### PR DESCRIPTION
(This is probably related to #14)

I found this issue that if RabbitMQ gracefully stopped, the sending queue will be halted indefinitely, even if the library successfully connected to other server. It seems that `AmqpConnectionManager` never fired `disconnect` event so the`ChannelWrapper` worker never stopped working and is still trying to send to the old channel.

Testing environment:

- RabbitMQ 3.6.10, Erlang 19.2.1 from `rabbitmq:management` image on Docker Hub
- Multiple instances of RabbitMQ running in a cluster
- Queue is a HA queue (ha-mode: all)

Steps to reproduce:

1. Produce a lot of messages and count the number of resolved publish promise (which is the number of messages sent)
2. On the node that the producer is connected to, run `rabbitmqctl stop_app`
3. Observe that the `connect` event on producer is triggered for the second time, but the number of sent messages no longer increase.