### PR TITLE
Support for per URL connection options

### DIFF
--- a/src/AmqpConnectionManager.js
+++ b/src/AmqpConnectionManager.js
@@ -128,13 +128,15 @@ export default class AmqpConnectionManager extends EventEmitter {
             this._currentUrl++;
 
             // url can be a string or object {url: string, connectionOptions?: object}
-            const amqpUrl = urlUtils.parse(url.url || url);
+            const urlString = url.url || url;
+            const connectionOptions = url.connectionOptions || this.connectionOptions;
+
+            const amqpUrl = urlUtils.parse(urlString);
             if(amqpUrl.search) {
                 amqpUrl.search += `&heartbeat=${this.heartbeatIntervalInSeconds}`;
             } else {
                 amqpUrl.search = `?heartbeat=${this.heartbeatIntervalInSeconds}`;
             }
-            const connectionOptions = url.connectionOptions || this.connectionOptions;
 
             return amqp.connect(urlUtils.format(amqpUrl), connectionOptions)
             .then(connection => {
@@ -171,7 +173,7 @@ export default class AmqpConnectionManager extends EventEmitter {
                 });
 
                 this._connecting = false;
-                this.emit('connect', { connection, url: amqpUrl.href });
+                this.emit('connect', { connection, url: urlString });
 
                 return null;
             });

--- a/src/AmqpConnectionManager.js
+++ b/src/AmqpConnectionManager.js
@@ -171,7 +171,7 @@ export default class AmqpConnectionManager extends EventEmitter {
                 });
 
                 this._connecting = false;
-                this.emit('connect', { connection, url });
+                this.emit('connect', { connection, url: amqpUrl.href });
 
                 return null;
             });

--- a/test/AmqpConnectionManagerTest.js
+++ b/test/AmqpConnectionManagerTest.js
@@ -33,6 +33,19 @@ describe('AmqpConnectionManager', function() {
         })
     );
 
+    it('should establish a url object based connection to a broker', () =>
+        new Promise(function(resolve, reject) {
+            amqp = new AmqpConnectionManager({url: 'amqp://localhost'});
+            return amqp.on('connect', ({ connection, url }) =>
+                Promise.resolve()
+                .then(() => {
+                    expect(url, 'url').to.equal('amqp://localhost');
+                    expect(connection.url, 'connection.url').to.equal('amqp://localhost?heartbeat=5');
+                }).then(resolve, reject)
+            );
+        })
+    );
+
     it('should close connection to a broker', () =>
         new Promise(function(resolve, reject) {
             amqp = new AmqpConnectionManager('amqp://localhost');
@@ -54,6 +67,21 @@ describe('AmqpConnectionManager', function() {
         new Promise(function(resolve, reject) {
             amqp = new AmqpConnectionManager(null, {
                 findServers() { return Promise.resolve('amqp://localhost'); }
+            });
+
+            return amqp.on('connect', ({ connection, url }) =>
+                Promise.resolve().then(function() {
+                    expect(url, 'url').to.equal('amqp://localhost');
+                    expect(connection.url, 'connection.url').to.equal('amqp://localhost?heartbeat=5');
+                }).then(resolve, reject)
+            );
+        })
+    );
+
+    it('should establish a url object based connection to a broker using findServers', () =>
+        new Promise(function(resolve, reject) {
+            amqp = new AmqpConnectionManager(null, {
+                findServers() { return Promise.resolve({url: 'amqp://localhost'}); }
             });
 
             return amqp.on('connect', ({ connection, url }) =>


### PR DESCRIPTION
Adds support for passing a url object {url: string, connectionOptions?: object} as an alternative to a url string. Adds associated tests.