### PR TITLE
Add disk persistance for _messages in case of service crash/reboot while disconnected from the amqp server

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Connection management for amqplib.
 * Automatically reconnect when your amqplib broker dies in a fire.
 * Round-robin connections between multiple brokers in a cluster.
 * If messages are sent while the broker is unavailable, queues messages in memory until we reconnect.
+* queued message are persisted to disk in case of unexpected crash/reboot, and recovered in memory.
 * Supports both promises and callbacks (using [promise-breaker](https://github.com/jwalton/node-promise-breaker))
 * Very un-opinionated library - a thin wrapper around amqplib.
 
@@ -133,6 +134,8 @@ Options:
   arbitrary data in.
 * `options.json` if true, then ChannelWrapper assumes all messages passed to `publish()` and `sendToQueue()`
    are plain JSON objects.  These will be encoded automatically before being sent.
+* `options.swap_path` if defined, then ChannelWrapper will persist the array of queued messages to disk.
+* `options.swap_size` the size of the storage (defaults to `50000`) see [node-localstorage](https://www.npmjs.com/package/node-localstorage).
 
 ### AmqpConnectionManager#isConnected()
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1715,6 +1715,14 @@
       "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
       "dev": true
     },
+    "@trusk/array-to-disk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@trusk/array-to-disk/-/array-to-disk-1.0.0.tgz",
+      "integrity": "sha512-ZNC5vWYfphXp/Kc+eIH/y3dvI+StyT/tbuzobQtm2lgSSvuq5FYTARd97KXOaTkMfYehS5dntiO31mbuh7QhkA==",
+      "requires": {
+        "node-localstorage": "1.3.1"
+      }
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -4694,8 +4702,7 @@
     "graceful-fs": {
       "version": "4.1.15",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
-      "dev": true
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA=="
     },
     "greenkeeper-lockfile": {
       "version": "1.15.1",
@@ -5078,8 +5085,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "3.2.0",
@@ -6368,6 +6374,26 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
       "dev": true
+    },
+    "node-localstorage": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/node-localstorage/-/node-localstorage-1.3.1.tgz",
+      "integrity": "sha512-NMWCSWWc6JbHT5PyWlNT2i8r7PgGYXVntmKawY83k/M0UJScZ5jirb61TLnqKwd815DfBQu+lR3sRw08SPzIaQ==",
+      "requires": {
+        "write-file-atomic": "^1.1.4"
+      },
+      "dependencies": {
+        "write-file-atomic": {
+          "version": "1.3.4",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
+          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "requires": {
+            "graceful-fs": "^4.1.11",
+            "imurmurhash": "^0.1.4",
+            "slide": "^1.1.5"
+          }
+        }
+      }
     },
     "node-modules-regexp": {
       "version": "1.0.0",
@@ -11399,6 +11425,11 @@
         "astral-regex": "^1.0.0",
         "is-fullwidth-code-point": "^2.0.0"
       }
+    },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "snapdragon": {
       "version": "0.8.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1716,9 +1716,9 @@
       "dev": true
     },
     "@trusk/array-to-disk": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@trusk/array-to-disk/-/array-to-disk-1.0.0.tgz",
-      "integrity": "sha512-ZNC5vWYfphXp/Kc+eIH/y3dvI+StyT/tbuzobQtm2lgSSvuq5FYTARd97KXOaTkMfYehS5dntiO31mbuh7QhkA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@trusk/array-to-disk/-/array-to-disk-1.1.0.tgz",
+      "integrity": "sha512-Tx3RVttvVBodfqR7Am/bawbb8JaS4HGQAgdgELmWvcjYO79idiACWArGJuoPx9XM0aja1UGAl+/Hv334rkaj3Q==",
       "requires": {
         "node-localstorage": "1.3.1"
       }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Auto-reconnect and round robin support for amqplib.",
   "main": "lib/index.js",
   "dependencies": {
+    "@trusk/array-to-disk": "1.0.0",
     "promise-breaker": "^5.0.0"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Auto-reconnect and round robin support for amqplib.",
   "main": "lib/index.js",
   "dependencies": {
-    "@trusk/array-to-disk": "1.0.0",
+    "@trusk/array-to-disk": "1.1.0",
     "promise-breaker": "^5.0.0"
   },
   "peerDependencies": {

--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -163,6 +163,7 @@ export default class ChannelWrapper extends EventEmitter {
 
         // Place to store queued messages.
         this._messages = new DiskArray(options.swap_path, options.swap_size);
+        this._messages.setEventEmitter(this, "droppedMessage");
         const messages_to_republish = [];
         while (this._messages.length) {
           messages_to_republish.push(this._messages.shift());

--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -168,10 +168,14 @@ export default class ChannelWrapper extends EventEmitter {
           messages_to_republish.push(this._messages.shift());
         }
         while (messages_to_republish.length) {
+          let content =
+            messages_to_republish[0].content.type === "Buffer"
+              ? Buffer.from(messages_to_republish[0].content)
+              : messages_to_republish[0].content;
           const args = [
             messages_to_republish[0].exchange || messages_to_republish[0].queue,
             messages_to_republish[0].routingKey,
-            messages_to_republish[0].content,
+            content,
             messages_to_republish[0].options
           ];
           this[messages_to_republish[0].type](...args);

--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -1,6 +1,8 @@
 import { EventEmitter } from 'events';
 import pb from 'promise-breaker';
 import DiskArray from '@trusk/array-to-disk';
+import rimraf from "rimraf";
+import path from "path";
 
 /**
  *  Calls to `publish()` or `sendToQueue()` work just like in amqplib, but messages are queued internally and
@@ -164,6 +166,9 @@ export default class ChannelWrapper extends EventEmitter {
         // Place to store queued messages.
         this._messages = new DiskArray(options.swap_path, options.swap_size);
         this._messages.setEventEmitter(this, "droppedMessage");
+        if (options.swap_path) {
+          rimraf.sync(`${path.resolve(options.swap_path)}/data.*`);
+        }
         const messages_to_republish = [];
         while (this._messages.length) {
           messages_to_republish.push(this._messages.shift());

--- a/test/ChannelWrapperTest.js
+++ b/test/ChannelWrapperTest.js
@@ -506,6 +506,7 @@ describe('ChannelWrapper', function() {
     });
 
     it('should encode JSON messages', function() {
+        // require("fs").writeFileSync("./swap/data", "[]"); // clean the swap
         connectionManager.simulateConnect();
         const channelWrapper = new ChannelWrapper(connectionManager, {
             json: true


### PR DESCRIPTION
Tell me if you want a commited version of disk array rather than depending on the module

NB: the messages in the channel wrapper all have resolve & reject functions, so I couldn't just load them from disk, I had to pipe them back through their publish or sendToQueue functions