### PR TITLE
Able to pass object as url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /npm-debug.log
 /coverage
 /.nyc_output
+/.vscode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.formatOnSave": false
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.formatOnSave": false
-}

--- a/src/AmqpConnectionManager.js
+++ b/src/AmqpConnectionManager.js
@@ -132,14 +132,22 @@ export default class AmqpConnectionManager extends EventEmitter {
             const urlString = url.url || url;
             const connectionOptions = url.connectionOptions || this.connectionOptions;
 
-            const amqpUrl = urlUtils.parse(urlString);
-            if(amqpUrl.search) {
-                amqpUrl.search += `&heartbeat=${this.heartbeatIntervalInSeconds}`;
-            } else {
-                amqpUrl.search = `?heartbeat=${this.heartbeatIntervalInSeconds}`;
+            let amqpUrl = null;
+
+            if(typeof urlString === "object") {
+                amqpUrl = url;
+            }else {
+                amqpUrl = urlUtils.parse(urlString);
+                if(amqpUrl.search) {
+                    amqpUrl.search += `&heartbeat=${this.heartbeatIntervalInSeconds}`;
+                } else {
+                    amqpUrl.search = `?heartbeat=${this.heartbeatIntervalInSeconds}`;
+                }
+                amqpUrl = urlUtils.format(amqpUrl);
             }
 
-            return amqp.connect(urlUtils.format(amqpUrl), connectionOptions)
+
+            return amqp.connect(amqpUrl, connectionOptions)
             .then(connection => {
                 this._currentConnection = connection;
 

--- a/src/ChannelWrapper.js
+++ b/src/ChannelWrapper.js
@@ -413,4 +413,19 @@ export default class ChannelWrapper extends EventEmitter {
     nackAll() {
         return this._channel && this._channel.nackAll.apply(this._channel, arguments);
     }
+
+    // Send a `purgeQueue` to the underlying channel.
+    purgeQueue() {
+        return this._channel && this._channel.purgeQueue.apply(this._channel, arguments);
+    }
+
+    // Send a `checkQueue` to the underlying channel.
+    checkQueue() {
+        return this._channel && this._channel.checkQueue.apply(this._channel, arguments);
+    }
+
+    // Send a `assertQueue` to the underlying channel.
+    assertQueue() {
+        return this._channel && this._channel.assertQueue.apply(this._channel, arguments);
+    }
 }


### PR DESCRIPTION
Allows for similar constructor call as amqplib:
```javascript
amqp.connect({
        protocol: protocol,
        hostname: host,
        port: port,
        username: username,
        password: password
      }).then(...);
```