### PR TITLE
fix(connectionOptions): resolves an issue where connectionOptions were not being passed into AMQPLIB

### DIFF
--- a/src/AmqpConnectionManager.ts
+++ b/src/AmqpConnectionManager.ts
@@ -288,12 +288,15 @@ export default class AmqpConnectionManager extends EventEmitter implements IAmqp
                 const url = this._urls[this._currentUrl];
                 this._currentUrl++;
 
-                let connectionOptions: ConnectionOptions | undefined;
+                // Set connectionOptions to the setting in the class instance (which came via the constructor)
+                let connectionOptions: ConnectionOptions | undefined = this.connectionOptions;
                 let originalUrl: string | amqp.Options.Connect;
                 let connect: string | amqp.Options.Connect;
 
                 if (typeof url === 'object' && 'url' in url) {
                     originalUrl = connect = url.url;
+                    // If URL is an object, pull out any specific URL connectionOptions for it or use the
+                    // instance connectionOptions if none were provided for this specific URL.
                     connectionOptions = url.connectionOptions || this.connectionOptions;
                 } else if (typeof url === 'string') {
                     originalUrl = connect = url;


### PR DESCRIPTION
Starting with version 3.4.0, the node-amqp-connection-manager introduced an issue where `connectionOptions` were not being passed into the underlying AMQPLIB connection causing some connections to not work. For example to connect to servers that require passing a self-signed CA, one needs to pass connectionOptions into node-amqp-connection-manager, which are then passed into amqp_opts for the underlying AMQPLIB.

This PR resolves this by once again setting `connectionOptions` properly.

This aims to solve https://github.com/jwalton/node-amqp-connection-manager/issues/173 and possibly https://github.com/jwalton/node-amqp-connection-manager/issues/172.