### PR TITLE
perf: resolve sent messages immediately

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -499,7 +499,7 @@ export default class ChannelWrapper extends EventEmitter {
                                             if (err) {
                                                 reject(err);
                                             } else {
-                                                setImmediate(() => resolve(result));
+                                                resolve(result);
                                             }
                                         }
                                     );
@@ -514,7 +514,7 @@ export default class ChannelWrapper extends EventEmitter {
                                             if (err) {
                                                 reject(err);
                                             } else {
-                                                setImmediate(() => resolve(result));
+                                                resolve(result);
                                             }
                                         }
                                     );


### PR DESCRIPTION
I can't find any reason why we wouldn't want to resolve immediately.

I would also argue that the resolved result might be unnecessary. In most cases I tested the 'drain' event was emitted before "resolve" was called, so the user might just be fooled by this result.