### PR TITLE
fix: fail waitForConnect on initial connect errors

### DIFF
--- a/src/ChannelWrapper.ts
+++ b/src/ChannelWrapper.ts
@@ -4,7 +4,7 @@ import * as crypto from 'crypto';
 import { EventEmitter } from 'events';
 import pb from 'promise-breaker';
 import { promisify } from 'util';
-import { IAmqpConnectionManager } from './AmqpConnectionManager.js';
+import { type ConnectFailedListener, IAmqpConnectionManager } from './AmqpConnectionManager.js';
 
 const MAX_MESSAGES_PER_BATCH = 1000;
 
@@ -262,17 +262,44 @@ export default class ChannelWrapper extends EventEmitter {
 
     /**
      * Returns a Promise which resolves when this channel next connects.
-     * (Mainly here for unit testing...)
+     *
+     * This Promise is also rejected if the connection manager emits
+     * `connectFailed` before a successful channel connect.
      *
      * @param [done] - Optional callback.
-     * @returns - Resolves when connected.
+     * @returns - Resolves when connected, rejects on initial connection failure.
      */
     waitForConnect(done?: pb.Callback<void>): Promise<void> {
         return pb.addCallback(
             done,
             this._channel && !this._settingUp
                 ? Promise.resolve()
-                : new Promise((resolve) => this.once('connect', resolve))
+                : new Promise<void>((resolve, reject) => {
+                      const onConnect = () => {
+                          cleanup();
+                          resolve();
+                      };
+
+                      const onConnectFailed: ConnectFailedListener = ({ err }) => {
+                          cleanup();
+                          reject(err);
+                      };
+
+                      const onClose = () => {
+                          cleanup();
+                          reject(new Error('Channel closed before connect'));
+                      };
+
+                      const cleanup = () => {
+                          this.off('connect', onConnect);
+                          this.off('close', onClose);
+                          this._connectionManager.off('connectFailed', onConnectFailed);
+                      };
+
+                      this.on('connect', onConnect);
+                      this.on('close', onClose);
+                      this._connectionManager.on('connectFailed', onConnectFailed);
+                  })
         );
     }
 

--- a/test/ChannelWrapperTest.ts
+++ b/test/ChannelWrapperTest.ts
@@ -161,6 +161,31 @@ describe('ChannelWrapper', function () {
         return channelWrapper.waitForConnect().then(() => channelWrapper.waitForConnect());
     });
 
+    it('should reject waitForConnect if initial connection fails', async function () {
+        const channelWrapper = new ChannelWrapper(connectionManager);
+
+        const waitPromise = channelWrapper.waitForConnect();
+        connectionManager.simulateConnectFailed(new Error('No route to host'));
+
+        await expect(waitPromise).to.be.rejectedWith('No route to host');
+    });
+
+    it('should pass initial connection failures to waitForConnect callback', function (done: any) {
+        const channelWrapper = new ChannelWrapper(connectionManager);
+
+        channelWrapper.waitForConnect((err) => {
+            try {
+                expect(err).to.be.an('error');
+                expect(err?.message).to.equal('No route to host');
+                done();
+            } catch (error: any) {
+                done(error);
+            }
+        });
+
+        connectionManager.simulateConnectFailed(new Error('No route to host'));
+    });
+
     it('should run setup functions immediately if already connected', async function () {
         const setup1 = jest.fn().mockImplementation(() => promiseTools.delay(10));
         const setup2 = jest.fn().mockImplementation(() => promiseTools.delay(10));
@@ -585,7 +610,6 @@ describe('ChannelWrapper', function () {
             channelWrapper.checkExchange('fish');
             expect(channel.checkExchange).to.have.beenCalledTimes(1);
             expect(channel.checkExchange).to.have.beenCalledWith('fish');
-            
         });
     });
 
@@ -607,7 +631,7 @@ describe('ChannelWrapper', function () {
             channelWrapper.bindQueue('dog', 'bone', 'legs');
             expect(channel.bindQueue).to.have.beenCalledTimes(1);
             expect(channel.bindQueue).to.have.beenCalledWith('dog', 'bone', 'legs', undefined);
-            
+
             channelWrapper.unbindQueue('dog', 'bone', 'legs');
             expect(channel.unbindQueue).to.have.beenCalledTimes(1);
             expect(channel.unbindQueue).to.have.beenCalledWith('dog', 'bone', 'legs', undefined);

--- a/test/fixtures.ts
+++ b/test/fixtures.ts
@@ -317,5 +317,14 @@ export class FakeAmqpConnectionManager extends EventEmitter implements IAmqpConn
         });
     }
 
+    simulateConnectFailed(err: Error = new Error('Connection failed')) {
+        this._connection = undefined;
+        this.connected = false;
+        this.emit('connectFailed', {
+            err,
+            url: 'amqp://localhost',
+        });
+    }
+
     async close() {}
 }


### PR DESCRIPTION
## What
- Make waitForConnect reject when initial connect fails (connectFailed).
- Keep existing resolve behavior when channel connects.
- Add tests for promise and callback error paths.

## Why
- Prevent boot code from hanging when broker DNS/auth is wrong.